### PR TITLE
Migrate deploy target to examples.luzmo.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,10 +43,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ matrix.name }}/node_modules
           key: ${{ runner.os }}-node-${{ matrix.name }}-${{ hashFiles(format('{0}/{1}', matrix.name, 'package-lock.json')) }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: dashboard-filter-panel
@@ -31,6 +32,10 @@ jobs:
           - name: react-chart-library
             outputFolder: dist/
           - name: react-luzmo-iq-playground
+            outputFolder: dist/
+          - name: newspaper
+            outputFolder: dist/newspaper/browser/
+          - name: dashboard-to-flex-grid
             outputFolder: dist/
 
     steps:
@@ -58,7 +63,7 @@ jobs:
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/
-          destination: s3://showcases.luzmo.com/${{ matrix.name }}/
+          destination: s3://examples.luzmo.com/${{ matrix.name }}/
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: eu-west-1
@@ -74,7 +79,7 @@ jobs:
       - name: Invalidate CloudFront
         uses: chetan/invalidate-cloudfront-action@v2
         env:
-          DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}
+          DISTRIBUTION: ${{ secrets.EXAMPLES_CLOUDFRONT_DISTRIBUTION_ID }}
           PATHS: "/*"
           AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/dashboard-filter-panel/README.md
+++ b/dashboard-filter-panel/README.md
@@ -7,7 +7,7 @@ tags:
   - Flex
 author: "Luzmo"
 image: "https://cdn.prod.website-files.com/64be9847db6f59a691b3503f/66cf4162aecd817a80bdbe3c_dashboard-filter-panel.png"
-url: "https://showcases.luzmo.com/dashboard-filter-panel/"
+url: "https://examples.luzmo.com/dashboard-filter-panel/"
 ---
 
 # Luzmo Flex showcase: Collapsible data filters

--- a/dashboard-to-flex-grid/README.md
+++ b/dashboard-to-flex-grid/README.md
@@ -7,7 +7,7 @@ tags:
   - Flex
 author: "Luzmo"
 image: "https://cdn.luzmo.com/showcases/dashboard-to-flex.png"
-url: "https://stackblitz.com/github.com/luzmo-official/flex-showcases/tree/main/dashboard-to-flex-grid?embed=1&file=README.md&hideNavigation=1&view=preview"
+url: "https://examples.luzmo.com/dashboard-to-flex-grid/"
 ---
 
 # Embed a Luzmo Dashboard as Flex elements in a CSS grid

--- a/dashboard-to-flex-grid/package.json
+++ b/dashboard-to-flex-grid/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:ci": "tsc && vite build --base=/dashboard-to-flex-grid/",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/drag-n-drop-chart-library/README.md
+++ b/drag-n-drop-chart-library/README.md
@@ -8,7 +8,7 @@ tags:
   - React
 author: "Luzmo"
 image: "https://cdn.prod.website-files.com/64be9847db6f59a691b3503f/66cf414e7fb20956e8c81943_drag-n-drop-chart-library.png"
-url: "https://showcases.luzmo.com/drag-n-drop-chart-library"
+url: "https://examples.luzmo.com/drag-n-drop-chart-library/"
 ---
 
 # Luzmo Flex showcase: Drag and drop chart library

--- a/drag-n-drop-chart-library/package.json
+++ b/drag-n-drop-chart-library/package.json
@@ -18,7 +18,7 @@
     "userflow.js": "^2.12.1",
     "web-vitals": "^2.1.4"
   },
-  "homepage": "https://showcases.luzmo.com/drag-n-drop-chart-library",
+  "homepage": "https://examples.luzmo.com/drag-n-drop-chart-library/",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/newspaper/README.md
+++ b/newspaper/README.md
@@ -6,6 +6,7 @@ tags:
   - Flex
 author: "Luzmo"
 image: "https://i.imgur.com/KDM5XG7.png"
+url: "https://examples.luzmo.com/newspaper/"
 ---
 
 # Newspaper Data Journalism

--- a/newspaper/package.json
+++ b/newspaper/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:ci": "npx ng build --base-href=/newspaper/",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },

--- a/react-chart-library/README.md
+++ b/react-chart-library/README.md
@@ -9,7 +9,7 @@ tags:
   - React
 author: "Luzmo"
 image: "https://cdn.luzmo.com/showcases/react-chart-library.png"
-url: "https://stackblitz.com/github/luzmo-official/flex-showcases/tree/main/react-chart-library?embed=1&file=README.md&hideNavigation=1&view=preview"
+url: "https://examples.luzmo.com/react-chart-library/"
 ---
 
 # Luzmo Chart Library example for react

--- a/react-chart-library/package.json
+++ b/react-chart-library/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:ci": "tsc -b && vite build --base=/react-chart-library/",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/react-luzmo-iq-playground/README.md
+++ b/react-luzmo-iq-playground/README.md
@@ -9,7 +9,7 @@ tags:
   - React
 author: "Luzmo"
 image: "https://cdn.luzmo.com/showcases/react-luzmo-iq-playground.png"
-url: "https://stackblitz.com/github/luzmo-official/flex-showcases/tree/main/react-luzmo-iq-playground?embed=1&file=README.md&hideNavigation=1&view=preview"
+url: "https://examples.luzmo.com/react-luzmo-iq-playground/"
 ---
 
 # React Luzmo IQ Playground

--- a/react-luzmo-iq-playground/package.json
+++ b/react-luzmo-iq-playground/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:ci": "tsc -b && vite build --base=/react-luzmo-iq-playground/",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/report-builder/README.md
+++ b/report-builder/README.md
@@ -9,7 +9,7 @@ tags:
   - Node.js
 author: "Luzmo"
 image: "https://cdn.prod.website-files.com/64be9847db6f59a691b3503f/66cf3e53a74e0b9c62b71a6d_report%20builder.png"
-url: "https://showcases.luzmo.com/report-builder/"
+url: "https://examples.luzmo.com/report-builder/"
 ---
 
 # Luzmo Flex showcase: Report builder

--- a/wearables-dashboard/README.md
+++ b/wearables-dashboard/README.md
@@ -7,7 +7,7 @@ tags:
   - React
 author: "Luzmo"
 image: "https://cdn.prod.website-files.com/64be9847db6f59a691b3503f/66cf414014a4d42e3957cf87_wearables-dashboard.png"
-url: "https://showcases.luzmo.com/wearables-dashboard"
+url: "https://examples.luzmo.com/wearables-dashboard/"
 ---
 
 # Luzmo Flex showcase: Personal health tracker


### PR DESCRIPTION
## Describe your changes

Moves the build and deploy pipeline from `showcases.luzmo.com` to `examples.luzmo.com` so all showcase apps live under the same domain as the gallery.

CI pipeline:
 - Deploy target is now `s3://examples.luzmo.com/<name>/`
 - CloudFront invalidation uses the new `EXAMPLES_CLOUDFRONT_DISTRIBUTION_ID` secret
 - `newspaper` and `dashboard-to-flex-grid` added to the build matrix
 - `build:ci` scripts with correct base paths added to the 4 showcases that were missing them
 - `actions/cache` and `actions/setup-node` bumped to v4
 - `fail-fast`: false added so one failing job doesn't cancel the others

README frontmatter:
 - All url fields updated to `examples.luzmo.com/<name>/`
 - `StackBlitz links` replaced with self-hosted URLs
 - `newspaper` gets a url for the first time

## Full link to Jira ticket

[PP-789](https://luzmo.atlassian.net/browse/PP-789)