### PR TITLE
Add fifa2026 to CI build matrix and CloudFront routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
             outputFolder: dist/newspaper/browser/
           - name: dashboard-to-flex-grid
             outputFolder: dist/
+          - name: fifa2026
+            outputFolder: dist/
 
     steps:
       - name: Checkout
@@ -50,6 +52,23 @@ jobs:
         with:
           path: ${{ matrix.name }}/node_modules
           key: ${{ runner.os }}-node-${{ matrix.name }}-${{ hashFiles(format('{0}/{1}', matrix.name, 'package-lock.json')) }}
+
+      - name: Set fifa2026 env vars
+        if: matrix.name == 'fifa2026'
+        run: |
+          echo "VITE_LUZMO_EMBED_KEY=${{ secrets.FIFA2026_VITE_LUZMO_EMBED_KEY }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_EMBED_TOKEN=${{ secrets.FIFA2026_VITE_LUZMO_EMBED_TOKEN }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_APP_SERVER=${{ secrets.FIFA2026_VITE_LUZMO_APP_SERVER }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_API_HOST=${{ secrets.FIFA2026_VITE_LUZMO_API_HOST }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_DATASET_GROUPS_ODDS=${{ secrets.FIFA2026_VITE_LUZMO_DATASET_GROUPS_ODDS }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_DATASET_TEAM_PROFILES=${{ secrets.FIFA2026_VITE_LUZMO_DATASET_TEAM_PROFILES }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_DATASET_HISTORICAL=${{ secrets.FIFA2026_VITE_LUZMO_DATASET_HISTORICAL }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_COLUMN_TEAM=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_TEAM }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_COLUMN_GROUP=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_GROUP }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_COLUMN_TOURNAMENT_WIN_PROB=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_TOURNAMENT_WIN_PROB }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_COLUMN_GROUP_ADVANCE_PROB=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_GROUP_ADVANCE_PROB }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_COLUMN_GROUP_WIN_PROB=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_GROUP_WIN_PROB }}" >> $GITHUB_ENV
+          echo "VITE_LUZMO_COLUMN_CONFEDERATION=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_CONFEDERATION }}" >> $GITHUB_ENV
 
       - name: Build front end
         run: |

--- a/devops-command/frontend/package.json
+++ b/devops-command/frontend/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:ci": "npx ng build --base-href=/devops-command/",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },

--- a/devops-command/frontend/src/app/services/embed-auth.service.ts
+++ b/devops-command/frontend/src/app/services/embed-auth.service.ts
@@ -55,7 +55,7 @@ export class EmbedAuthService {
       locale_id: 'en'
     };
 
-    this.http.post<LuzmoEmbedResponse>('http://localhost:3101/api/embed', payload).subscribe({
+    this.http.post<LuzmoEmbedResponse>('/api/showcases/devops-command/embed', payload).subscribe({
       next: (response) => {
         this.embedResponse.set(response);
         this.isLoading.set(false);

--- a/embedded-ai-chart/frontend/package.json
+++ b/embedded-ai-chart/frontend/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "NG_BUILD_PARALLEL_TS=0 ng serve",
     "build": "ng build",
+    "build:ci": "npx ng build --base-href=/embedded-ai-chart/",
     "watch": "ng build --watch --configuration development"
   },
   "private": true,

--- a/embedded-ai-chart/frontend/src/app/shared/services/luzmo.service.ts
+++ b/embedded-ai-chart/frontend/src/app/shared/services/luzmo.service.ts
@@ -13,10 +13,10 @@ export class LuzmoService {
   ) {}
 
   retrieveAuthorization(dashboard_ids: string[], dataset_ids: string[]): Observable<AuthorizationResult> {
-    return this.httpClient.post(`${this.configService.apiUrl}/retrieve-embed-token`, { dashboard_ids, dataset_ids }) as Observable<AuthorizationResult>;
+    return this.httpClient.post(`${this.configService.apiUrl}/embed-token`, { dashboard_ids, dataset_ids }) as Observable<AuthorizationResult>;
   }
 
   retrieveAIChart(dataset_id: string, question: string, message_history?: any[]): Observable<AIChart> {
-    return this.httpClient.post(`${this.configService.apiUrl}/retrieve-ai-chart`, { dataset_id, question, message_history }) as Observable<AIChart>;
+    return this.httpClient.post(`${this.configService.apiUrl}/ai-chart`, { dataset_id, question, message_history }) as Observable<AIChart>;
   }
 }

--- a/embedded-ai-chart/frontend/src/assets/config.prod.json
+++ b/embedded-ai-chart/frontend/src/assets/config.prod.json
@@ -1,3 +1,3 @@
 {
-  "apiUrl": "https://ai-showcases-api.luzmo.com"
+  "apiUrl": "/api/showcases/embedded-ai-chart"
 }

--- a/fifa2026/README.md
+++ b/fifa2026/README.md
@@ -9,6 +9,7 @@ tags:
   - Vue
   - TypeScript
 author: "Luzmo"
+url: "https://examples.luzmo.com/fifa2026/"
 ---
 
 # Luzmo Flex showcase: World Cup 2026 Analytics Explorer

--- a/fifa2026/package.json
+++ b/fifa2026/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
+    "build:ci": "vue-tsc -b && vite build --base=/fifa2026/",
     "preview": "vite preview",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",

--- a/the-constructor/package.json
+++ b/the-constructor/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:ci": "tsc && vite build --base=/the-constructor/",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/the-constructor/src/luzmo/config.ts
+++ b/the-constructor/src/luzmo/config.ts
@@ -1,11 +1,12 @@
 // ---------------------------------------------------------------------------
 // Luzmo Configuration
 // ---------------------------------------------------------------------------
-// Reads Luzmo credentials and collection ID from Vite environment variables.
+// Reads Luzmo embed credentials and collection ID from Vite environment variables.
+// Embed key-token pairs are scoped and safe to use from the browser.
 
 export const luzmoConfig = {
-  apiKey: import.meta.env.VITE_LUZMO_API_KEY as string,
-  apiToken: import.meta.env.VITE_LUZMO_API_TOKEN as string,
+  embedKey: import.meta.env.VITE_LUZMO_EMBED_KEY as string,
+  embedToken: import.meta.env.VITE_LUZMO_EMBED_TOKEN as string,
   collectionId: import.meta.env.VITE_COLLECTION_ID as string,
 };
 

--- a/the-constructor/src/luzmo/fetch-dashboard.ts
+++ b/the-constructor/src/luzmo/fetch-dashboard.ts
@@ -38,8 +38,8 @@ export async function fetchDashboardRow(
 
   const payload = {
     action: 'get',
-    key: luzmoConfig.apiKey,
-    token: luzmoConfig.apiToken,
+    key: luzmoConfig.embedKey,
+    token: luzmoConfig.embedToken,
     version: '0.1.0',
     find: {
       where: {
@@ -94,8 +94,8 @@ export async function fetchTheme(
 
   const payload = {
     action: 'get',
-    key: luzmoConfig.apiKey,
-    token: luzmoConfig.apiToken,
+    key: luzmoConfig.embedKey,
+    token: luzmoConfig.embedToken,
     version: '0.1.0',
     find: {
       where: {
@@ -145,8 +145,8 @@ export async function fetchCollectionDashboards(
 
   const payload = {
     action: 'get',
-    key: luzmoConfig.apiKey,
-    token: luzmoConfig.apiToken,
+    key: luzmoConfig.embedKey,
+    token: luzmoConfig.embedToken,
     version: '0.1.0',
     find: {
       where: {
@@ -211,8 +211,8 @@ export async function fetchAIExampleQuestions(
   const payload = {
     action: 'create',
     version: '0.1.0',
-    key: luzmoConfig.apiKey,
-    token: luzmoConfig.apiToken,
+    key: luzmoConfig.embedKey,
+    token: luzmoConfig.embedToken,
     properties: {
       type: 'generate-example-questions',
       dataset_id: datasetId,
@@ -257,8 +257,8 @@ export async function generateAIChart(
   const payload = {
     action: 'create',
     version: '0.1.0',
-    key: luzmoConfig.apiKey,
-    token: luzmoConfig.apiToken,
+    key: luzmoConfig.embedKey,
+    token: luzmoConfig.embedToken,
     properties: {
       type: 'generate-chart',
       dataset_id: datasetId,


### PR DESCRIPTION
## Describe your changes

 - Add fifa2026 (Vite + Vue) to the d`eploy.yml` build matrix with a conditional step to inject `FIFA2026_*` secrets as `VITE_*` env vars.
- Set base href to `/fifa2026/` and update README url frontmatter.
- Add `fifa2026` to the Pulumi showcases list in showcase-library so the CloudFront Function routes SPA requests correctly.

## Full link to Jira ticket

[PP-789](https://luzmo.atlassian.net/browse/PP-789)