### PR TITLE
fix(cfo-cockpit): remove embed token setup

### DIFF
--- a/cfo-cockpit/AGENTS.md
+++ b/cfo-cockpit/AGENTS.md
@@ -14,7 +14,9 @@
 
 ## Luzmo (embedded analytics)
 
-When implementing Luzmo functionality (Embed tokens, core API, Flex SDK, or Luzmo IQ), refer to Luzmo's [AGENTS.md](https://developer.luzmo.com/agents.md) file for official best practices.
+This showcase is intentionally wired to a public Luzmo dataset and does not pass any auth or embed token.
+
+When implementing Luzmo functionality (core API, Flex SDK, or Luzmo IQ), refer to Luzmo's [AGENTS.md](https://developer.luzmo.com/agents.md) file for official best practices.
 
 When implementing Luzmo ACK functionality, there is currently no documentation on the web. Use the `ack_llms.txt` file in the project root as documentation.
 

--- a/cfo-cockpit/README.md
+++ b/cfo-cockpit/README.md
@@ -39,14 +39,16 @@ Scenario-driven financial planning experience built on [Luzmo ACK](https://www.n
    npm install
    ```
 
-2. Set your Luzmo credentials. Add a script tag in `src/index.html` before `</head>`:
+2. Set your Luzmo **embed** credentials (not API key/token). You can find these in your Luzmo account under Embed > Security. Add a script tag in `src/index.html` before `</head>`:
 
    ```html
    <script>
-     window.__LUZMO_AUTH_KEY__ = 'your-api-key';
-     window.__LUZMO_AUTH_TOKEN__ = 'your-api-token';
+     window.__LUZMO_AUTH_KEY__ = 'your-embed-key';
+     window.__LUZMO_AUTH_TOKEN__ = 'your-embed-token';
    </script>
    ```
+
+   > **Warning:** Do not use your API key/token here. API credentials grant full backend access and must never be exposed in frontend code. Embed credentials are scoped to dashboard rendering only.
 
 3. Start the dev server:
 

--- a/cfo-cockpit/README.md
+++ b/cfo-cockpit/README.md
@@ -19,6 +19,8 @@ image: "./screenshot.png"
 
 Scenario-driven financial planning experience built on [Luzmo ACK](https://www.npmjs.com/package/@luzmo/analytics-components-kit) and Angular 17.
 
+This showcase is intentionally wired to a public Luzmo dataset and does not pass any auth or embed token.
+
 ## Features
 
 - **Scenario switching** — Base, Stretch, and Stress planning cases with context-aware board narrative
@@ -39,24 +41,21 @@ Scenario-driven financial planning experience built on [Luzmo ACK](https://www.n
    npm install
    ```
 
-2. Set your Luzmo **embed** credentials (not API key/token). You can find these in your Luzmo account under Embed > Security. Add a script tag in `src/index.html` before `</head>`:
-
-   ```html
-   <script>
-     window.__LUZMO_AUTH_KEY__ = 'your-embed-key';
-     window.__LUZMO_AUTH_TOKEN__ = 'your-embed-token';
-   </script>
-   ```
-
-   > **Warning:** Do not use your API key/token here. API credentials grant full backend access and must never be exposed in frontend code. Embed credentials are scoped to dashboard rendering only.
-
-3. Start the dev server:
+2. Start the dev server:
 
    ```bash
    npm start
    ```
 
    Open [http://localhost:3001](http://localhost:3001).
+
+No `.env` file, injected globals, or token setup is required.
+
+## Auth Model
+
+This showcase does not pass `authKey`, `authToken`, or any embed token to ACK components.
+
+It is designed to run as-is against the public CFO dataset so anyone copying the example can immediately see that no token exchange is part of the setup.
 
 ## Build
 

--- a/cfo-cockpit/src/app/app.component.html
+++ b/cfo-cockpit/src/app/app.component.html
@@ -194,8 +194,6 @@
           class="ack-grid"
           [appServer]="appServer"
           [apiHost]="gridApiHost"
-          [authKey]="authKey"
-          [authToken]="authToken"
           [language]="'en'"
           [contentLanguage]="'en'"
           [columns]="48"
@@ -330,8 +328,6 @@
                   [language]="'en'"
                   [contentLanguage]="'en'"
                   [apiUrl]="apiHost"
-                  [authKey]="authKey"
-                  [authToken]="authToken"
                   [grows]="true"
                   (luzmo-slots-contents-changed)="onSlotsContentsChanged($event)"
                   (luzmo-slot-constraint-triggered)="onSlotConstraintTriggered($event)"
@@ -344,8 +340,6 @@
                   [search]="'on'"
                   [language]="'en'"
                   [apiUrl]="apiHost"
-                  [authKey]="authKey"
-                  [authToken]="authToken"
                   [draggableDataFieldVariant]="'highlight'"
                 >
                 </luzmo-draggable-data-fields-panel>
@@ -360,8 +354,6 @@
                   [options]="selectedItem.options ?? {}"
                   [language]="'en'"
                   [apiUrl]="apiHost"
-                  [authKey]="authKey"
-                  [authToken]="authToken"
                   (luzmo-options-changed)="onOptionsChanged($event)"
                 >
                 </luzmo-edit-item>

--- a/cfo-cockpit/src/app/app.component.ts
+++ b/cfo-cockpit/src/app/app.component.ts
@@ -57,11 +57,6 @@ import {
   normalizeGlobalFilters
 } from './cfo-view-helpers';
 
-interface RuntimeConfig {
-  __LUZMO_AUTH_KEY__?: string;
-  __LUZMO_AUTH_TOKEN__?: string;
-}
-
 @Component({
   selector: 'app-root',
   standalone: true,
@@ -87,7 +82,6 @@ export class AppComponent implements OnInit, OnDestroy {
   private readonly initialItemTemplatesById = new Map(
     this.initialItemTemplates.filter((item): item is GridItemData & { id: string } => Boolean(item.id)).map((item) => [item.id, item])
   );
-  private readonly runtimeConfig = globalThis as typeof globalThis & RuntimeConfig;
   private readonly browserLocation = globalThis.location;
   private readonly cdr = inject(ChangeDetectorRef);
   readonly currentOrigin = this.browserLocation.origin;
@@ -98,9 +92,6 @@ export class AppComponent implements OnInit, OnDestroy {
   readonly apiHost = API_HOST;
   readonly gridApiHost = this.apiHost;
   readonly datasetIds = [DATASET_ID];
-
-  readonly authKey = this.runtimeConfig.__LUZMO_AUTH_KEY__?.trim() ?? '';
-  readonly authToken = this.runtimeConfig.__LUZMO_AUTH_TOKEN__?.trim() ?? '';
 
   readonly periodOptions = PERIOD_OPTIONS;
   readonly regionOptions = REGION_OPTIONS;


### PR DESCRIPTION
## Summary
- removes the runtime embed token wiring from the CFO cockpit showcase
- stops passing `authKey` and `authToken` to ACK components
- updates the README and local AGENTS doc to make it explicit that this showcase runs against a public dataset with no token setup

## Test plan
- [x] `cd cfo-cockpit && npm run build`
- [x] `cd cfo-cockpit && npm start`
- [x] verify `http://localhost:3001` loads the cockpit locally
- [x] verify local proxy calls to `/0.1.0/securable` succeed without a token
- [x] verify local proxy calls to `/0.1.0/data` succeed without a token
- [x] verify the served bundle no longer contains runtime auth wiring

## Notes
- the CFO dataset used by this showcase is public, so no token exchange is required for this example
- `cfo-cockpit/package-lock.json` remains untracked locally and is not part of this PR
