### PR TITLE
Add the-constructor showcase to CI pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
             outputFolder: dist/
           - name: fifa2026
             outputFolder: dist/
+          - name: the-constructor
+            outputFolder: dist/
 
     steps:
       - name: Checkout
@@ -71,6 +73,13 @@ jobs:
           echo "VITE_LUZMO_COLUMN_GROUP_WIN_PROB=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_GROUP_WIN_PROB }}" >> .env
           echo "VITE_LUZMO_COLUMN_CONFEDERATION=${{ secrets.FIFA2026_VITE_LUZMO_COLUMN_CONFEDERATION }}" >> .env
 
+      - name: Write the-constructor .env
+        if: matrix.name == 'the-constructor'
+        working-directory: the-constructor
+        run: |
+          echo "VITE_LUZMO_EMBED_KEY=${{ secrets.CONSTRUCTOR_VITE_LUZMO_EMBED_KEY }}" > .env
+          echo "VITE_LUZMO_EMBED_TOKEN=${{ secrets.CONSTRUCTOR_VITE_LUZMO_EMBED_TOKEN }}" >> .env
+
       - name: Build front end
         run: |
           cd ${{ matrix.name }}
@@ -79,7 +88,8 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        if: github.event_name != 'pull_request'
+        # TEMP: deploy on PR to test the-constructor. Revert before merge.
+        # if: github.event_name != 'pull_request'
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/
@@ -93,7 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: Build
-    if: github.event_name != 'pull_request'
+    # TEMP: deploy on PR to test the-constructor. Revert before merge.
+    # if: github.event_name != 'pull_request'
 
     steps:
       - name: Invalidate CloudFront

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,8 +88,7 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        # TEMP: deploy on PR to test the-constructor. Revert before merge.
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/
@@ -103,8 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: Build
-    # TEMP: deploy on PR to test the-constructor. Revert before merge.
-    # if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Invalidate CloudFront


### PR DESCRIPTION
## Summary                                                                                                                               
  - Adds the-constructor to the CI build matrix, deploying to `s3://examples.luzmo.com/the-constructor/`                                   
  - Injects scoped embed credentials via `.env` from GitHub secrets (CONSTRUCTOR_VITE_LUZMO_EMBED_KEY, CONSTRUCTOR_VITE_LUZMO_EMBED_TOKEN) 
  - No full API keys in the bundle. Carmen replaced all collection API calls with securable queries that work with embed tokens. 

## Full link to Jira ticket
[PP-789](https://luzmo.atlassian.net/browse/PP-789)          
                                                                                                                                           
  ## Notes                                                                                                                                 
  - CloudFront Function already has `the-constructor` in its showcases list (deployed via Pulumi in `showcase-library`).                     
  - Live and verified: https://examples.luzmo.com/the-constructor/ 