### PR TITLE
Add devops-command and embedded-ai-chart to build matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,10 @@ jobs:
             outputFolder: dist/
           - name: the-constructor
             outputFolder: dist/
+          - name: devops-command
+            outputFolder: frontend/dist/devops-command/browser/
+          - name: embedded-ai-chart
+            outputFolder: frontend/dist/ai-showcases-frontend/browser/
 
     steps:
       - name: Checkout
@@ -88,7 +92,7 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'  # temporarily disabled for PP-789 testing
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/
@@ -102,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: Build
-    if: github.event_name != 'pull_request'
+    # if: github.event_name != 'pull_request'  # temporarily disabled for PP-789 testing
 
     steps:
       - name: Invalidate CloudFront

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        # if: github.event_name != 'pull_request'  # temporarily disabled for PP-789 testing
+        if: github.event_name != 'pull_request'
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: Build
-    # if: github.event_name != 'pull_request'  # temporarily disabled for PP-789 testing
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Invalidate CloudFront

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'  # temporarily disabled for PP-789 testing
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Copy Folder
         uses: keithweaver/aws-s3-github-action@v1.0.0
-        # if: github.event_name != 'pull_request'  # temporarily disabled for PP-789 testing
+        if: github.event_name != 'pull_request'
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/

--- a/devops-command/README.md
+++ b/devops-command/README.md
@@ -8,6 +8,7 @@ tags:
   - Flex
 author: "Luzmo"
 image: "https://i.imgur.com/95MX7Gy.png"
+url: "https://examples.luzmo.com/devops-command/"
 ---
 
 # DevOps Command

--- a/devops-command/frontend/angular.json
+++ b/devops-command/frontend/angular.json
@@ -33,8 +33,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "1MB",
+                  "maximumError": "2MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/devops-command/package.json
+++ b/devops-command/package.json
@@ -7,7 +7,8 @@
     "install-all": "npm install && cd backend && npm install && cd ../frontend && npm install",
     "start": "concurrently \"npm run backend\" \"npm run frontend\" --names \"backend,frontend\" --prefix-colors \"blue,green\"",
     "backend": "cd backend && npm run start:dev",
-    "frontend": "cd frontend && npm run start"
+    "frontend": "cd frontend && npm run start",
+    "build:ci": "cd frontend && npm ci && npm run build:ci"
   },
   "devDependencies": {
     "concurrently": "9.2.1"

--- a/devops-command/package.json
+++ b/devops-command/package.json
@@ -8,7 +8,7 @@
     "start": "concurrently \"npm run backend\" \"npm run frontend\" --names \"backend,frontend\" --prefix-colors \"blue,green\"",
     "backend": "cd backend && npm run start:dev",
     "frontend": "cd frontend && npm run start",
-    "build:ci": "cd frontend && npm ci && npm run build:ci"
+    "build:ci": "cd frontend && npm install && npm run build:ci"
   },
   "devDependencies": {
     "concurrently": "9.2.1"

--- a/embedded-ai-chart/README.md
+++ b/embedded-ai-chart/README.md
@@ -8,7 +8,7 @@ tags:
   - Flex
 author: "Luzmo"
 image: "https://cdn.prod.website-files.com/64be9847db6f59a691b3503f/66d84032abfc71dbb38bbcd7_embedded_ai_chart_generator.png"
-url: "https://ai-showcases.luzmo.com/embedded-chart-generator"
+url: "https://examples.luzmo.com/embedded-ai-chart/"
 ---
 
 # Luzmo Flex showcase: AI chart generator

--- a/embedded-ai-chart/package.json
+++ b/embedded-ai-chart/package.json
@@ -6,6 +6,6 @@
   "author": "Luzmo Team",
   "type": "module",
   "scripts": {
-    "build:ci": "cd frontend && npm ci && npm run build:ci"
+    "build:ci": "cd frontend && npm install && npm run build:ci"
   }
 }

--- a/embedded-ai-chart/package.json
+++ b/embedded-ai-chart/package.json
@@ -4,5 +4,8 @@
   "description": "",
   "main": "index.js",
   "author": "Luzmo Team",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "build:ci": "cd frontend && npm ci && npm run build:ci"
+  }
 }


### PR DESCRIPTION
## Summary
- Added `devops-command` and `embedded-ai-chart` to the CI build matrix
- Both now build and deploy to `s3://examples.luzmo.com/<name>/` on merge to main                                                          
- Added root-level `build:ci` scripts that build the frontend subfolder for each                                                           
- Raised `devops-command` Angular budget from `1MB` to `2MB` (bundle is `1.09MB` due to Luzmo embed SDK)                                         
- Updated `README` frontmatter: added url field for `devops-command`, updated url for `embedded-ai-chart` to point to `examples.luzmo.com ` 

## Full link to Jira ticket
[PP-789](https://luzmo.atlassian.net/browse/PP-789)