### PR TITLE
fix(cfo-cockpit): update ACK imports for 1.0.1-alpha.151

### DIFF
--- a/cfo-cockpit/package.json
+++ b/cfo-cockpit/package.json
@@ -17,7 +17,7 @@
     "@angular/platform-browser": "^17.3.0",
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
-    "@luzmo/analytics-components-kit": "^1.0.1-alpha.147",
+    "@luzmo/analytics-components-kit": "1.0.1-alpha.151",
     "@luzmo/icons": "^1.0.1-alpha.33",
     "@luzmo/lucero": "^1.0.1-alpha.62",
     "lit": "^3.3.1",

--- a/cfo-cockpit/src/app/app.component.html
+++ b/cfo-cockpit/src/app/app.component.html
@@ -189,7 +189,7 @@
           </div>
         </div>
 
-        <luzmo-grid
+        <luzmo-item-grid
           #gridHost
           class="ack-grid"
           [appServer]="appServer"
@@ -206,11 +206,11 @@
           [defaultItemActionsMenu]="activeGridActionsMenu"
           [placementItemActionsMenu]="'bottom-end'"
           (click)="onGridSurfaceClick($event)"
-          (luzmo-grid-ready)="onGridReady()"
-          (luzmo-grid-changed)="onGridChanged($event)"
-          (luzmo-grid-item-action)="onGridItemAction($event)"
+          (luzmo-item-grid-ready)="onGridReady()"
+          (luzmo-item-grid-changed)="onGridChanged($event)"
+          (luzmo-item-grid-item-action)="onGridItemAction($event)"
         >
-        </luzmo-grid>
+        </luzmo-item-grid>
       </article>
     </section>
 
@@ -324,7 +324,7 @@
 
             @if (builderTab === 'data') {
               <div class="builder-body">
-                <luzmo-item-data-drop-panel
+                <luzmo-item-slot-drop-panel
                   [itemType]="selectedItem.type"
                   [slotsContents]="selectedItem.slots ?? []"
                   [language]="'en'"
@@ -336,9 +336,9 @@
                   (luzmo-slots-contents-changed)="onSlotsContentsChanged($event)"
                   (luzmo-slot-constraint-triggered)="onSlotConstraintTriggered($event)"
                 >
-                </luzmo-item-data-drop-panel>
+                </luzmo-item-slot-drop-panel>
 
-                <luzmo-draggable-data-fields-panel
+                <luzmo-data-field-panel
                   [datasetIds]="datasetIds"
                   [datasetPicker]="false"
                   [search]="'on'"
@@ -348,13 +348,13 @@
                   [authToken]="authToken"
                   [draggableDataFieldVariant]="'highlight'"
                 >
-                </luzmo-draggable-data-fields-panel>
+                </luzmo-data-field-panel>
               </div>
             }
 
             @if (builderTab === 'options') {
               <div class="builder-body">
-                <luzmo-edit-item
+                <luzmo-item-option-panel
                   [itemType]="selectedItem.type"
                   [slots]="selectedItem.slots ?? []"
                   [options]="selectedItem.options ?? {}"
@@ -364,7 +364,7 @@
                   [authToken]="authToken"
                   (luzmo-options-changed)="onOptionsChanged($event)"
                 >
-                </luzmo-edit-item>
+                </luzmo-item-option-panel>
               </div>
             }
           } @else {

--- a/cfo-cockpit/src/app/app.component.ts
+++ b/cfo-cockpit/src/app/app.component.ts
@@ -644,7 +644,7 @@ export class AppComponent implements OnInit, OnDestroy {
         continue;
       }
 
-      const itemId = node.getAttribute('luzmo-grid-item-id') ?? node.getAttribute('gs-id');
+      const itemId = node.getAttribute('luzmo-item-grid-item-id') ?? node.getAttribute('gs-id');
 
       if (itemId) {
         return itemId;
@@ -679,9 +679,9 @@ export class AppComponent implements OnInit, OnDestroy {
       return null;
     }
 
-    const item = target.closest('.luzmo-grid-item') as HTMLElement | null;
+    const item = target.closest('.luzmo-item-grid-item') as HTMLElement | null;
 
-    return item?.getAttribute('luzmo-grid-item-id') ?? null;
+    return item?.getAttribute('luzmo-item-grid-item-id') ?? null;
   }
 
   private createDefaultItemsModel(): GridItemData[] {
@@ -1075,10 +1075,10 @@ export class AppComponent implements OnInit, OnDestroy {
         return;
       }
 
-      const tiles = Array.from(shadowRoot.querySelectorAll<HTMLElement>('.luzmo-grid-item'));
+      const tiles = Array.from(shadowRoot.querySelectorAll<HTMLElement>('.luzmo-item-grid-item'));
 
       for (const tile of tiles) {
-        const tileId = tile.getAttribute('luzmo-grid-item-id');
+        const tileId = tile.getAttribute('luzmo-item-grid-item-id');
         const isSelected = Boolean(!this.isFixedView && this.selectedItemId && tileId === this.selectedItemId);
 
         tile.style.transition = 'box-shadow 150ms ease, border-color 150ms ease';
@@ -1135,7 +1135,7 @@ export class AppComponent implements OnInit, OnDestroy {
         resizeHandleDetected = true;
       }
 
-      if (!tile && node.classList.contains('luzmo-grid-item')) {
+      if (!tile && node.classList.contains('luzmo-item-grid-item')) {
         tile = node;
       }
     }

--- a/cfo-cockpit/src/main.ts
+++ b/cfo-cockpit/src/main.ts
@@ -1,7 +1,7 @@
-import '@luzmo/analytics-components-kit/draggable-data-fields-panel';
-import '@luzmo/analytics-components-kit/edit-item';
-import '@luzmo/analytics-components-kit/grid';
-import '@luzmo/analytics-components-kit/item-data-drop-panel';
+import '@luzmo/analytics-components-kit/data-field-panel';
+import '@luzmo/analytics-components-kit/item-option-panel';
+import '@luzmo/analytics-components-kit/item-grid';
+import '@luzmo/analytics-components-kit/item-slot-drop-panel';
 import '@luzmo/lucero/action-button';
 import '@luzmo/lucero/action-group';
 import '@luzmo/lucero/button';


### PR DESCRIPTION
## Summary
- Fixes broken build caused by renamed subpath exports in `@luzmo/analytics-components-kit` >= `.148`
- `grid` → `item-grid`, `edit-item` → `item-option-panel`, `draggable-data-fields-panel` → `data-field-panel`, `item-data-drop-panel` → `item-slot-drop-panel`
- Updates HTML tags and event names to match
- Updates shadow DOM selectors (`.luzmo-grid-item` → `.luzmo-item-grid-item`)
- Pins ACK to `1.0.1-alpha.151` (no caret) to prevent future breakage

## Test plan
- [ ] CI build passes
- [ ] `cd cfo-cockpit && npm install && npm run build` succeeds locally
- [ ] App renders correctly with grid, data panel, and option panel components

🤖 Generated with [Claude Code](https://claude.com/claude-code)