### PR TITLE
feat(ci): add flexcalidraw to build and deploy pipeline 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
           npm run build:ci
 
       - name: Copy Folder
-        if: matrix.name != 'flexcalidraw'
+        if: github.event_name != 'pull_request' && matrix.name != 'flexcalidraw'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
@@ -126,7 +126,7 @@ jobs:
           flags: --recursive
 
       - name: Copy Folder (flexcalidraw)
-        if: matrix.name == 'flexcalidraw'
+        if: github.event_name != 'pull_request' && matrix.name == 'flexcalidraw'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
@@ -138,6 +138,7 @@ jobs:
           flags: --recursive
 
   Invalidate_Cloudfront:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
 
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -109,7 +114,7 @@ jobs:
           npm run build:ci
 
       - name: Copy Folder
-        if: github.event_name != 'pull_request' && matrix.name != 'flexcalidraw'
+        if: matrix.name != 'flexcalidraw'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
@@ -121,7 +126,7 @@ jobs:
           flags: --recursive
 
       - name: Copy Folder (flexcalidraw)
-        if: github.event_name != 'pull_request' && matrix.name == 'flexcalidraw'
+        if: matrix.name == 'flexcalidraw'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
@@ -133,7 +138,6 @@ jobs:
           flags: --recursive
 
   Invalidate_Cloudfront:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,6 @@ on:
     branches:
       - main
 
-  pull_request:
-    types:
-      - opened
-      - synchronize
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -53,6 +48,8 @@ jobs:
             outputFolder: dist/
           - name: guided-chart-creator
             outputFolder: out/
+          - name: flexcalidraw
+            outputFolder: excalidraw-app/build/
 
     steps:
       - name: Checkout
@@ -92,18 +89,43 @@ jobs:
           echo "VITE_LUZMO_EMBED_KEY=${{ secrets.CONSTRUCTOR_VITE_LUZMO_EMBED_KEY }}" > .env
           echo "VITE_LUZMO_EMBED_TOKEN=${{ secrets.CONSTRUCTOR_VITE_LUZMO_EMBED_TOKEN }}" >> .env
 
+      - name: Clone flexcalidraw repo
+        if: matrix.name == 'flexcalidraw'
+        run: |
+          git clone https://github.com/luzmo-official/flexcalidraw.git flexcalidraw-build
+
+      - name: Build flexcalidraw
+        if: matrix.name == 'flexcalidraw'
+        run: |
+          cd flexcalidraw-build
+          yarn install --frozen-lockfile
+          VITE_APP_DISABLE_SENTRY=true yarn --cwd ./excalidraw-app vite build --base=/flexcalidraw/
+
       - name: Build front end
+        if: matrix.name != 'flexcalidraw'
         run: |
           cd ${{ matrix.name }}
           npm ci
           npm run build:ci
 
       - name: Copy Folder
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && matrix.name != 'flexcalidraw'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
           source: ./${{ matrix.name }}/${{ matrix.outputFolder }}/
+          destination: s3://examples.luzmo.com/${{ matrix.name }}/
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: eu-west-1
+          flags: --recursive
+
+      - name: Copy Folder (flexcalidraw)
+        if: github.event_name != 'pull_request' && matrix.name == 'flexcalidraw'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./flexcalidraw-build/${{ matrix.outputFolder }}/
           destination: s3://examples.luzmo.com/${{ matrix.name }}/
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/flexcalidraw/README.md
+++ b/flexcalidraw/README.md
@@ -9,6 +9,7 @@ tags:
   - Editing
 author: "Luzmo"
 image: "https://cdn.luzmo.com/showcases/flexcalidraw.gif"
+url: "https://examples.luzmo.com/flexcalidraw/"
 ---
 
 # Excalidraw Fork: Luzmo + ACK Editing


### PR DESCRIPTION
## Describe your change

Add `flexcalidraw` to the CI build and deploy pipeline. Since it lives in a separate repo, the workflow clones it at build time, builds with Yarn and Vite, and deploys to S3. Also adds the url frontmatter field to the flexcalidraw README for the gallery "Explore live demo" button.