### PR TITLE
fix: clone flexcalidraw from luzmo-official public repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Clone flexcalidraw repo
         if: matrix.name == 'flexcalidraw'
         run: |
-          git clone https://${{ secrets.GH_PAT }}@github.com/cumulio-internal/flexcalidraw.git flexcalidraw-build
+          git clone https://github.com/luzmo-official/flexcalidraw.git flexcalidraw-build
 
       - name: Build flexcalidraw
         if: matrix.name == 'flexcalidraw'


### PR DESCRIPTION
Switch `flexcalidraw` clone URL back to the public `luzmo-official/flexcalidraw` repo. The internal repo was archived by Joost. No PAT needed since the repo is public.