### PR TITLE
feat(sustain-iq): add ESG dashboard showcase with CI pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,8 @@ jobs:
             outputFolder: excalidraw-app/build/
           - name: ack-maps-builder
             outputFolder: dist/
+          - name: sustain-iq
+            outputFolder: dist/
 
     steps:
       - name: Checkout
@@ -104,6 +106,14 @@ jobs:
         run: |
           echo "VITE_LUZMO_EMBED_KEY=${{ secrets.CONSTRUCTOR_VITE_LUZMO_EMBED_KEY }}" > .env
           echo "VITE_LUZMO_EMBED_TOKEN=${{ secrets.CONSTRUCTOR_VITE_LUZMO_EMBED_TOKEN }}" >> .env
+
+      - name: Write sustain-iq .env
+        if: matrix.name == 'sustain-iq'
+        working-directory: sustain-iq
+        run: |
+          echo "VITE_LUZMO_EMBED_KEY=${{ secrets.SUSTAIN_IQ_VITE_LUZMO_EMBED_KEY }}" > .env
+          echo "VITE_LUZMO_EMBED_TOKEN=${{ secrets.SUSTAIN_IQ_VITE_LUZMO_EMBED_TOKEN }}" >> .env
+          echo "VITE_LUZMO_DATASET_ID=${{ secrets.SUSTAIN_IQ_VITE_LUZMO_DATASET_ID }}" >> .env
 
       - name: Clone flexcalidraw repo
         if: matrix.name == 'flexcalidraw'

--- a/sustain-iq/package.json
+++ b/sustain-iq/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:ci": "tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/sustain-iq/vite.config.ts
+++ b/sustain-iq/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
+  base: mode === 'production' ? '/sustain-iq/' : '/',
   server: {
     port: 5173,
   },
-});
+}));


### PR DESCRIPTION
## Describe your change

Adds the `sustain-iq` ESG dashboard to the CI deploy matrix. Build-time credentials (embed key, embed token, dataset ID) are injected via GitHub secrets `SUSTAIN_IQ_VITE_*`. Vite base path set to `/sustain-iq/` for subpath deployment. CloudFront routing already updated via `showcase-library`.

## Link to Jira ticket

[PP-829](https://luzmo.atlassian.net/browse/PP-829)