### PR TITLE
Only build changed showcases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,8 @@ jobs:
       flexcalidraw: ${{ steps.filter.outputs.flexcalidraw }}
       ack_maps_builder: ${{ steps.filter.outputs.ack_maps_builder }}
       sustain_iq: ${{ steps.filter.outputs.sustain_iq }}
-      workflow: ${{ steps.filter.outputs.workflow }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      has_changes: ${{ steps.matrix.outputs.has_changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,8 +48,6 @@ jobs:
           base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           filters: |
-            workflow:
-              - '.github/workflows/deploy.yml'
             dashboard_filter_panel:
               - 'dashboard-filter-panel/**'
             report_builder:
@@ -82,7 +81,6 @@ jobs:
 
       - name: Debug changed outputs
         run: |
-          echo "workflow=${{ steps.filter.outputs.workflow }}"
           echo "dashboard_filter_panel=${{ steps.filter.outputs.dashboard_filter_panel }}"
           echo "report_builder=${{ steps.filter.outputs.report_builder }}"
           echo "wearables_dashboard=${{ steps.filter.outputs.wearables_dashboard }}"
@@ -99,60 +97,63 @@ jobs:
           echo "ack_maps_builder=${{ steps.filter.outputs.ack_maps_builder }}"
           echo "sustain_iq=${{ steps.filter.outputs.sustain_iq }}"
 
+      - name: Build matrix
+        id: matrix
+        env:
+          DASHBOARD_FILTER_PANEL_CHANGED: ${{ steps.filter.outputs.dashboard_filter_panel }}
+          REPORT_BUILDER_CHANGED: ${{ steps.filter.outputs.report_builder }}
+          WEARABLES_DASHBOARD_CHANGED: ${{ steps.filter.outputs.wearables_dashboard }}
+          NEWSPAPER_CHANGED: ${{ steps.filter.outputs.newspaper }}
+          DASHBOARD_TO_FLEX_GRID_CHANGED: ${{ steps.filter.outputs.dashboard_to_flex_grid }}
+          FIFA2026_CHANGED: ${{ steps.filter.outputs.fifa2026 }}
+          THE_CONSTRUCTOR_CHANGED: ${{ steps.filter.outputs.the_constructor }}
+          DEVOPS_COMMAND_CHANGED: ${{ steps.filter.outputs.devops_command }}
+          EURO2024_CHANGED: ${{ steps.filter.outputs.euro2024 }}
+          CFO_COCKPIT_CHANGED: ${{ steps.filter.outputs.cfo_cockpit }}
+          BLOCK_TYPE_EDITOR_CHANGED: ${{ steps.filter.outputs.block_type_editor }}
+          GUIDED_CHART_CREATOR_CHANGED: ${{ steps.filter.outputs.guided_chart_creator }}
+          FLEXCALIDRAW_CHANGED: ${{ steps.filter.outputs.flexcalidraw }}
+          ACK_MAPS_BUILDER_CHANGED: ${{ steps.filter.outputs.ack_maps_builder }}
+          SUSTAIN_IQ_CHANGED: ${{ steps.filter.outputs.sustain_iq }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+
+          const showcases = [
+            { name: 'dashboard-filter-panel', changed: process.env.DASHBOARD_FILTER_PANEL_CHANGED, outputFolder: 'dist/dashboard-filter-panel/browser/' },
+            { name: 'report-builder', changed: process.env.REPORT_BUILDER_CHANGED, outputFolder: 'dist/report-builder/browser/' },
+            { name: 'wearables-dashboard', changed: process.env.WEARABLES_DASHBOARD_CHANGED, outputFolder: 'dist/' },
+            { name: 'newspaper', changed: process.env.NEWSPAPER_CHANGED, outputFolder: 'dist/newspaper/browser/' },
+            { name: 'dashboard-to-flex-grid', changed: process.env.DASHBOARD_TO_FLEX_GRID_CHANGED, outputFolder: 'dist/' },
+            { name: 'fifa2026', changed: process.env.FIFA2026_CHANGED, outputFolder: 'dist/' },
+            { name: 'the-constructor', changed: process.env.THE_CONSTRUCTOR_CHANGED, outputFolder: 'dist/' },
+            { name: 'devops-command', changed: process.env.DEVOPS_COMMAND_CHANGED, outputFolder: 'frontend/dist/devops-command/browser/' },
+            { name: 'euro2024', changed: process.env.EURO2024_CHANGED, outputFolder: 'dist/euro2024-showcase/browser/' },
+            { name: 'cfo-cockpit', changed: process.env.CFO_COCKPIT_CHANGED, outputFolder: 'dist/cfo-angular-product/browser/' },
+            { name: 'block-type-editor', changed: process.env.BLOCK_TYPE_EDITOR_CHANGED, outputFolder: 'dist/' },
+            { name: 'guided-chart-creator', changed: process.env.GUIDED_CHART_CREATOR_CHANGED, outputFolder: 'out/' },
+            { name: 'flexcalidraw', changed: process.env.FLEXCALIDRAW_CHANGED, outputFolder: 'excalidraw-app/build/' },
+            { name: 'ack-maps-builder', changed: process.env.ACK_MAPS_BUILDER_CHANGED, outputFolder: 'dist/' },
+            { name: 'sustain-iq', changed: process.env.SUSTAIN_IQ_CHANGED, outputFolder: 'dist/' },
+          ];
+
+          const include = showcases.filter((showcase) => showcase.changed === 'true');
+
+          const matrix = JSON.stringify({ include });
+          console.log(matrix);
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${matrix}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `has_changes=${include.length > 0}\n`);
+          NODE
+
   Build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
+    if: ${{ needs.changes.outputs.has_changes == 'true' }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: dashboard-filter-panel
-            changed: ${{ needs.changes.outputs.dashboard_filter_panel }}
-            outputFolder: dist/dashboard-filter-panel/browser/
-          - name: report-builder
-            changed: ${{ needs.changes.outputs.report_builder }}
-            outputFolder: dist/report-builder/browser/
-          - name: wearables-dashboard
-            changed: ${{ needs.changes.outputs.wearables_dashboard }}
-            outputFolder: dist/
-          - name: newspaper
-            changed: ${{ needs.changes.outputs.newspaper }}
-            outputFolder: dist/newspaper/browser/
-          - name: dashboard-to-flex-grid
-            changed: ${{ needs.changes.outputs.dashboard_to_flex_grid }}
-            outputFolder: dist/
-          - name: fifa2026
-            changed: ${{ needs.changes.outputs.fifa2026 }}
-            outputFolder: dist/
-          - name: the-constructor
-            changed: ${{ needs.changes.outputs.the_constructor }}
-            outputFolder: dist/
-          - name: devops-command
-            changed: ${{ needs.changes.outputs.devops_command }}
-            outputFolder: frontend/dist/devops-command/browser/
-          - name: euro2024
-            changed: ${{ needs.changes.outputs.euro2024 }}
-            outputFolder: dist/euro2024-showcase/browser/
-          - name: cfo-cockpit
-            changed: ${{ needs.changes.outputs.cfo_cockpit }}
-            outputFolder: dist/cfo-angular-product/browser/
-          - name: block-type-editor
-            changed: ${{ needs.changes.outputs.block_type_editor }}
-            outputFolder: dist/
-          - name: guided-chart-creator
-            changed: ${{ needs.changes.outputs.guided_chart_creator }}
-            outputFolder: out/
-          - name: flexcalidraw
-            changed: ${{ needs.changes.outputs.flexcalidraw }}
-            outputFolder: excalidraw-app/build/
-          - name: ack-maps-builder
-            changed: ${{ needs.changes.outputs.ack_maps_builder }}
-            outputFolder: dist/
-          - name: sustain-iq
-            changed: ${{ needs.changes.outputs.sustain_iq }}
-            outputFolder: dist/
-    if: ${{ needs.changes.outputs.workflow == 'true' || matrix.changed == 'true' }}
+      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,43 +14,124 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed showcases
+    runs-on: ubuntu-latest
+    outputs:
+      dashboard_filter_panel: ${{ steps.filter.outputs.dashboard_filter_panel }}
+      report_builder: ${{ steps.filter.outputs.report_builder }}
+      wearables_dashboard: ${{ steps.filter.outputs.wearables_dashboard }}
+      newspaper: ${{ steps.filter.outputs.newspaper }}
+      dashboard_to_flex_grid: ${{ steps.filter.outputs.dashboard_to_flex_grid }}
+      fifa2026: ${{ steps.filter.outputs.fifa2026 }}
+      the_constructor: ${{ steps.filter.outputs.the_constructor }}
+      devops_command: ${{ steps.filter.outputs.devops_command }}
+      euro2024: ${{ steps.filter.outputs.euro2024 }}
+      cfo_cockpit: ${{ steps.filter.outputs.cfo_cockpit }}
+      block_type_editor: ${{ steps.filter.outputs.block_type_editor }}
+      guided_chart_creator: ${{ steps.filter.outputs.guided_chart_creator }}
+      flexcalidraw: ${{ steps.filter.outputs.flexcalidraw }}
+      ack_maps_builder: ${{ steps.filter.outputs.ack_maps_builder }}
+      sustain_iq: ${{ steps.filter.outputs.sustain_iq }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute path changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            workflow:
+              - '.github/workflows/deploy.yml'
+            dashboard_filter_panel:
+              - 'dashboard-filter-panel/**'
+            report_builder:
+              - 'report-builder/**'
+            wearables_dashboard:
+              - 'wearables-dashboard/**'
+            newspaper:
+              - 'newspaper/**'
+            dashboard_to_flex_grid:
+              - 'dashboard-to-flex-grid/**'
+            fifa2026:
+              - 'fifa2026/**'
+            the_constructor:
+              - 'the-constructor/**'
+            devops_command:
+              - 'devops-command/**'
+            euro2024:
+              - 'euro2024/**'
+            cfo_cockpit:
+              - 'cfo-cockpit/**'
+            block_type_editor:
+              - 'block-type-editor/**'
+            guided_chart_creator:
+              - 'guided-chart-creator/**'
+            flexcalidraw:
+              - 'flexcalidraw/**'
+            ack_maps_builder:
+              - 'ack-maps-builder/**'
+            sustain_iq:
+              - 'sustain-iq/**'
+
   Build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: dashboard-filter-panel
+            changeKey: dashboard_filter_panel
             outputFolder: dist/dashboard-filter-panel/browser/
           - name: report-builder
+            changeKey: report_builder
             outputFolder: dist/report-builder/browser/
           - name: wearables-dashboard
+            changeKey: wearables_dashboard
             outputFolder: dist/
           - name: newspaper
+            changeKey: newspaper
             outputFolder: dist/newspaper/browser/
           - name: dashboard-to-flex-grid
+            changeKey: dashboard_to_flex_grid
             outputFolder: dist/
           - name: fifa2026
+            changeKey: fifa2026
             outputFolder: dist/
           - name: the-constructor
+            changeKey: the_constructor
             outputFolder: dist/
           - name: devops-command
+            changeKey: devops_command
             outputFolder: frontend/dist/devops-command/browser/
           - name: euro2024
+            changeKey: euro2024
             outputFolder: dist/euro2024-showcase/browser/
           - name: cfo-cockpit
+            changeKey: cfo_cockpit
             outputFolder: dist/cfo-angular-product/browser/
           - name: block-type-editor
+            changeKey: block_type_editor
             outputFolder: dist/
           - name: guided-chart-creator
+            changeKey: guided_chart_creator
             outputFolder: out/
           - name: flexcalidraw
+            changeKey: flexcalidraw
             outputFolder: excalidraw-app/build/
           - name: ack-maps-builder
+            changeKey: ack_maps_builder
             outputFolder: dist/
           - name: sustain-iq
+            changeKey: sustain_iq
             outputFolder: dist/
+    if: ${{ needs.changes.outputs.workflow == 'true' || needs.changes.outputs[matrix.changeKey] == 'true' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           filters: |
             workflow:
               - '.github/workflows/deploy.yml'
@@ -77,6 +79,25 @@ jobs:
               - 'ack-maps-builder/**'
             sustain_iq:
               - 'sustain-iq/**'
+
+      - name: Debug changed outputs
+        run: |
+          echo "workflow=${{ steps.filter.outputs.workflow }}"
+          echo "dashboard_filter_panel=${{ steps.filter.outputs.dashboard_filter_panel }}"
+          echo "report_builder=${{ steps.filter.outputs.report_builder }}"
+          echo "wearables_dashboard=${{ steps.filter.outputs.wearables_dashboard }}"
+          echo "newspaper=${{ steps.filter.outputs.newspaper }}"
+          echo "dashboard_to_flex_grid=${{ steps.filter.outputs.dashboard_to_flex_grid }}"
+          echo "fifa2026=${{ steps.filter.outputs.fifa2026 }}"
+          echo "the_constructor=${{ steps.filter.outputs.the_constructor }}"
+          echo "devops_command=${{ steps.filter.outputs.devops_command }}"
+          echo "euro2024=${{ steps.filter.outputs.euro2024 }}"
+          echo "cfo_cockpit=${{ steps.filter.outputs.cfo_cockpit }}"
+          echo "block_type_editor=${{ steps.filter.outputs.block_type_editor }}"
+          echo "guided_chart_creator=${{ steps.filter.outputs.guided_chart_creator }}"
+          echo "flexcalidraw=${{ steps.filter.outputs.flexcalidraw }}"
+          echo "ack_maps_builder=${{ steps.filter.outputs.ack_maps_builder }}"
+          echo "sustain_iq=${{ steps.filter.outputs.sustain_iq }}"
 
   Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,51 +87,51 @@ jobs:
       matrix:
         include:
           - name: dashboard-filter-panel
-            changeKey: dashboard_filter_panel
+            changed: ${{ needs.changes.outputs.dashboard_filter_panel }}
             outputFolder: dist/dashboard-filter-panel/browser/
           - name: report-builder
-            changeKey: report_builder
+            changed: ${{ needs.changes.outputs.report_builder }}
             outputFolder: dist/report-builder/browser/
           - name: wearables-dashboard
-            changeKey: wearables_dashboard
+            changed: ${{ needs.changes.outputs.wearables_dashboard }}
             outputFolder: dist/
           - name: newspaper
-            changeKey: newspaper
+            changed: ${{ needs.changes.outputs.newspaper }}
             outputFolder: dist/newspaper/browser/
           - name: dashboard-to-flex-grid
-            changeKey: dashboard_to_flex_grid
+            changed: ${{ needs.changes.outputs.dashboard_to_flex_grid }}
             outputFolder: dist/
           - name: fifa2026
-            changeKey: fifa2026
+            changed: ${{ needs.changes.outputs.fifa2026 }}
             outputFolder: dist/
           - name: the-constructor
-            changeKey: the_constructor
+            changed: ${{ needs.changes.outputs.the_constructor }}
             outputFolder: dist/
           - name: devops-command
-            changeKey: devops_command
+            changed: ${{ needs.changes.outputs.devops_command }}
             outputFolder: frontend/dist/devops-command/browser/
           - name: euro2024
-            changeKey: euro2024
+            changed: ${{ needs.changes.outputs.euro2024 }}
             outputFolder: dist/euro2024-showcase/browser/
           - name: cfo-cockpit
-            changeKey: cfo_cockpit
+            changed: ${{ needs.changes.outputs.cfo_cockpit }}
             outputFolder: dist/cfo-angular-product/browser/
           - name: block-type-editor
-            changeKey: block_type_editor
+            changed: ${{ needs.changes.outputs.block_type_editor }}
             outputFolder: dist/
           - name: guided-chart-creator
-            changeKey: guided_chart_creator
+            changed: ${{ needs.changes.outputs.guided_chart_creator }}
             outputFolder: out/
           - name: flexcalidraw
-            changeKey: flexcalidraw
+            changed: ${{ needs.changes.outputs.flexcalidraw }}
             outputFolder: excalidraw-app/build/
           - name: ack-maps-builder
-            changeKey: ack_maps_builder
+            changed: ${{ needs.changes.outputs.ack_maps_builder }}
             outputFolder: dist/
           - name: sustain-iq
-            changeKey: sustain_iq
+            changed: ${{ needs.changes.outputs.sustain_iq }}
             outputFolder: dist/
-    if: ${{ needs.changes.outputs.workflow == 'true' || needs.changes.outputs[matrix.changeKey] == 'true' }}
+    if: ${{ needs.changes.outputs.workflow == 'true' || matrix.changed == 'true' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       has_changes: ${{ steps.detect.outputs.has_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,129 +18,58 @@ jobs:
     name: Detect changed showcases
     runs-on: ubuntu-latest
     outputs:
-      dashboard_filter_panel: ${{ steps.filter.outputs.dashboard_filter_panel }}
-      report_builder: ${{ steps.filter.outputs.report_builder }}
-      wearables_dashboard: ${{ steps.filter.outputs.wearables_dashboard }}
-      newspaper: ${{ steps.filter.outputs.newspaper }}
-      dashboard_to_flex_grid: ${{ steps.filter.outputs.dashboard_to_flex_grid }}
-      fifa2026: ${{ steps.filter.outputs.fifa2026 }}
-      the_constructor: ${{ steps.filter.outputs.the_constructor }}
-      devops_command: ${{ steps.filter.outputs.devops_command }}
-      euro2024: ${{ steps.filter.outputs.euro2024 }}
-      cfo_cockpit: ${{ steps.filter.outputs.cfo_cockpit }}
-      block_type_editor: ${{ steps.filter.outputs.block_type_editor }}
-      guided_chart_creator: ${{ steps.filter.outputs.guided_chart_creator }}
-      flexcalidraw: ${{ steps.filter.outputs.flexcalidraw }}
-      ack_maps_builder: ${{ steps.filter.outputs.ack_maps_builder }}
-      sustain_iq: ${{ steps.filter.outputs.sustain_iq }}
-      matrix: ${{ steps.matrix.outputs.matrix }}
-      has_changes: ${{ steps.matrix.outputs.has_changes }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Compute path changes
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          filters: |
-            dashboard_filter_panel:
-              - 'dashboard-filter-panel/**'
-            report_builder:
-              - 'report-builder/**'
-            wearables_dashboard:
-              - 'wearables-dashboard/**'
-            newspaper:
-              - 'newspaper/**'
-            dashboard_to_flex_grid:
-              - 'dashboard-to-flex-grid/**'
-            fifa2026:
-              - 'fifa2026/**'
-            the_constructor:
-              - 'the-constructor/**'
-            devops_command:
-              - 'devops-command/**'
-            euro2024:
-              - 'euro2024/**'
-            cfo_cockpit:
-              - 'cfo-cockpit/**'
-            block_type_editor:
-              - 'block-type-editor/**'
-            guided_chart_creator:
-              - 'guided-chart-creator/**'
-            flexcalidraw:
-              - 'flexcalidraw/**'
-            ack_maps_builder:
-              - 'ack-maps-builder/**'
-            sustain_iq:
-              - 'sustain-iq/**'
-
-      - name: Debug changed outputs
-        run: |
-          echo "dashboard_filter_panel=${{ steps.filter.outputs.dashboard_filter_panel }}"
-          echo "report_builder=${{ steps.filter.outputs.report_builder }}"
-          echo "wearables_dashboard=${{ steps.filter.outputs.wearables_dashboard }}"
-          echo "newspaper=${{ steps.filter.outputs.newspaper }}"
-          echo "dashboard_to_flex_grid=${{ steps.filter.outputs.dashboard_to_flex_grid }}"
-          echo "fifa2026=${{ steps.filter.outputs.fifa2026 }}"
-          echo "the_constructor=${{ steps.filter.outputs.the_constructor }}"
-          echo "devops_command=${{ steps.filter.outputs.devops_command }}"
-          echo "euro2024=${{ steps.filter.outputs.euro2024 }}"
-          echo "cfo_cockpit=${{ steps.filter.outputs.cfo_cockpit }}"
-          echo "block_type_editor=${{ steps.filter.outputs.block_type_editor }}"
-          echo "guided_chart_creator=${{ steps.filter.outputs.guided_chart_creator }}"
-          echo "flexcalidraw=${{ steps.filter.outputs.flexcalidraw }}"
-          echo "ack_maps_builder=${{ steps.filter.outputs.ack_maps_builder }}"
-          echo "sustain_iq=${{ steps.filter.outputs.sustain_iq }}"
-
-      - name: Build matrix
-        id: matrix
+      - name: Detect changed showcases
+        id: detect
         env:
-          DASHBOARD_FILTER_PANEL_CHANGED: ${{ steps.filter.outputs.dashboard_filter_panel }}
-          REPORT_BUILDER_CHANGED: ${{ steps.filter.outputs.report_builder }}
-          WEARABLES_DASHBOARD_CHANGED: ${{ steps.filter.outputs.wearables_dashboard }}
-          NEWSPAPER_CHANGED: ${{ steps.filter.outputs.newspaper }}
-          DASHBOARD_TO_FLEX_GRID_CHANGED: ${{ steps.filter.outputs.dashboard_to_flex_grid }}
-          FIFA2026_CHANGED: ${{ steps.filter.outputs.fifa2026 }}
-          THE_CONSTRUCTOR_CHANGED: ${{ steps.filter.outputs.the_constructor }}
-          DEVOPS_COMMAND_CHANGED: ${{ steps.filter.outputs.devops_command }}
-          EURO2024_CHANGED: ${{ steps.filter.outputs.euro2024 }}
-          CFO_COCKPIT_CHANGED: ${{ steps.filter.outputs.cfo_cockpit }}
-          BLOCK_TYPE_EDITOR_CHANGED: ${{ steps.filter.outputs.block_type_editor }}
-          GUIDED_CHART_CREATOR_CHANGED: ${{ steps.filter.outputs.guided_chart_creator }}
-          FLEXCALIDRAW_CHANGED: ${{ steps.filter.outputs.flexcalidraw }}
-          ACK_MAPS_BUILDER_CHANGED: ${{ steps.filter.outputs.ack_maps_builder }}
-          SUSTAIN_IQ_CHANGED: ${{ steps.filter.outputs.sustain_iq }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          REF_SHA: ${{ github.sha }}
         run: |
+          if [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            BASE_SHA="$(git rev-list --max-parents=0 "$REF_SHA")"
+          fi
+
+          git diff --name-only "$BASE_SHA" "$REF_SHA" > changed-files.txt
+          echo "Changed files:"
+          cat changed-files.txt
+
           node <<'NODE'
           const fs = require('fs');
 
           const showcases = [
-            { name: 'dashboard-filter-panel', changed: process.env.DASHBOARD_FILTER_PANEL_CHANGED, outputFolder: 'dist/dashboard-filter-panel/browser/' },
-            { name: 'report-builder', changed: process.env.REPORT_BUILDER_CHANGED, outputFolder: 'dist/report-builder/browser/' },
-            { name: 'wearables-dashboard', changed: process.env.WEARABLES_DASHBOARD_CHANGED, outputFolder: 'dist/' },
-            { name: 'newspaper', changed: process.env.NEWSPAPER_CHANGED, outputFolder: 'dist/newspaper/browser/' },
-            { name: 'dashboard-to-flex-grid', changed: process.env.DASHBOARD_TO_FLEX_GRID_CHANGED, outputFolder: 'dist/' },
-            { name: 'fifa2026', changed: process.env.FIFA2026_CHANGED, outputFolder: 'dist/' },
-            { name: 'the-constructor', changed: process.env.THE_CONSTRUCTOR_CHANGED, outputFolder: 'dist/' },
-            { name: 'devops-command', changed: process.env.DEVOPS_COMMAND_CHANGED, outputFolder: 'frontend/dist/devops-command/browser/' },
-            { name: 'euro2024', changed: process.env.EURO2024_CHANGED, outputFolder: 'dist/euro2024-showcase/browser/' },
-            { name: 'cfo-cockpit', changed: process.env.CFO_COCKPIT_CHANGED, outputFolder: 'dist/cfo-angular-product/browser/' },
-            { name: 'block-type-editor', changed: process.env.BLOCK_TYPE_EDITOR_CHANGED, outputFolder: 'dist/' },
-            { name: 'guided-chart-creator', changed: process.env.GUIDED_CHART_CREATOR_CHANGED, outputFolder: 'out/' },
-            { name: 'flexcalidraw', changed: process.env.FLEXCALIDRAW_CHANGED, outputFolder: 'excalidraw-app/build/' },
-            { name: 'ack-maps-builder', changed: process.env.ACK_MAPS_BUILDER_CHANGED, outputFolder: 'dist/' },
-            { name: 'sustain-iq', changed: process.env.SUSTAIN_IQ_CHANGED, outputFolder: 'dist/' },
+            { name: 'dashboard-filter-panel', outputFolder: 'dist/dashboard-filter-panel/browser/' },
+            { name: 'report-builder', outputFolder: 'dist/report-builder/browser/' },
+            { name: 'wearables-dashboard', outputFolder: 'dist/' },
+            { name: 'newspaper', outputFolder: 'dist/newspaper/browser/' },
+            { name: 'dashboard-to-flex-grid', outputFolder: 'dist/' },
+            { name: 'fifa2026', outputFolder: 'dist/' },
+            { name: 'the-constructor', outputFolder: 'dist/' },
+            { name: 'devops-command', outputFolder: 'frontend/dist/devops-command/browser/' },
+            { name: 'euro2024', outputFolder: 'dist/euro2024-showcase/browser/' },
+            { name: 'cfo-cockpit', outputFolder: 'dist/cfo-angular-product/browser/' },
+            { name: 'block-type-editor', outputFolder: 'dist/' },
+            { name: 'guided-chart-creator', outputFolder: 'out/' },
+            { name: 'flexcalidraw', outputFolder: 'excalidraw-app/build/' },
+            { name: 'ack-maps-builder', outputFolder: 'dist/' },
+            { name: 'sustain-iq', outputFolder: 'dist/' },
           ];
 
-          const include = showcases.filter((showcase) => showcase.changed === 'true');
+          const changedFiles = fs.readFileSync('changed-files.txt', 'utf8')
+            .split(/\r?\n/)
+            .filter(Boolean);
+          const include = showcases.filter((showcase) =>
+            changedFiles.some((file) => file === showcase.name || file.startsWith(`${showcase.name}/`))
+          );
 
           const matrix = JSON.stringify({ include });
-          console.log(matrix);
+          console.log(`Build matrix: ${matrix}`);
 
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${matrix}\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `has_changes=${include.length > 0}\n`);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
   changes:
     name: Detect changed showcases
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
       has_changes: ${{ steps.detect.outputs.has_changes }}

--- a/dashboard-filter-panel/README.md
+++ b/dashboard-filter-panel/README.md
@@ -10,7 +10,7 @@ image: "https://cdn.prod.website-files.com/64be9847db6f59a691b3503f/66cf4162aecd
 url: "https://examples.luzmo.com/dashboard-filter-panel/"
 ---
 
-# Luzmo Flex showcase: Collapsible data filters
+# Luzmo Flex showcase: Collapsible data filters panel
 
 ## Installation
 


### PR DESCRIPTION
Enhance GitHub Actions workflow to detect changes in showcases and conditionally build them.

Adapted files in dashboard-filter-panel as a test

Bonus: Updated to use actions/checkout@v5 for Node 24 runtime given upcoming node 20 runtime deprecation