### PR TITLE
fix: wire luzmo-filters to active chart dataset

### DIFF
--- a/guided-chart-creator/README.md
+++ b/guided-chart-creator/README.md
@@ -36,11 +36,13 @@ Users select data fields, pick a chart type, fine-tune options and filters, then
 
 ## Getting Started
 
-1. Copy `.env.example` to `.env.local` and configure your datasets:
+1. (Optional) Copy `.env.example` to `.env.local` to restrict the data-field picker to specific datasets:
 
    ```env
    NEXT_PUBLIC_LUZMO_DATASET_IDS=your-dataset-id-1,your-dataset-id-2
    ```
+
+   Public datasets work without this file. Chart filters use the dataset(s) linked in the chart slots, not this env var.
 
    No API keys or embed tokens are needed — the app works directly with public datasets.
 

--- a/guided-chart-creator/components/report-builder/context.tsx
+++ b/guided-chart-creator/components/report-builder/context.tsx
@@ -256,14 +256,15 @@ function reducer(state: AppState, action: Action): AppState {
 interface AppContextValue {
   state: AppState
   dispatch: React.Dispatch<Action>
-  datasetIds: string[]
+  /** Optional env allow-list for luzmo-data-field-panel only */
+  allowedDatasetIds: string[]
 }
 
 const AppContext = createContext<AppContextValue | null>(null)
 
 export function AppProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState)
-  const { datasetIds } = useLuzmoDatasets()
+  const { allowedDatasetIds } = useLuzmoDatasets()
 
   // Theme persistence
   useEffect(() => {
@@ -317,7 +318,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       value={{
         state,
         dispatch,
-        datasetIds,
+        allowedDatasetIds,
       }}
     >
       {children}

--- a/guided-chart-creator/components/report-builder/guided-wizard.tsx
+++ b/guided-chart-creator/components/report-builder/guided-wizard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ArrowRight, ArrowDown, Database, Settings, Bug, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
@@ -21,7 +21,12 @@ import "@luzmo/analytics-components-kit/filters"
 import { LuzmoItemOptionPanel, LuzmoFilters } from "@luzmo/analytics-components-kit/react"
 
 import type { DraftItem, VizItemSlots } from "@/lib/luzmo-types"
-import { getNextItemPosition, normalizeSlotsContents, inferChartType } from "@/lib/luzmo-types"
+import {
+  getNextItemPosition,
+  normalizeSlotsContents,
+  inferChartType,
+  getDatasetIdsFromSlots,
+} from "@/lib/luzmo-types"
 import { guidedWizard as copy } from "@/lib/guidance-copy"
 import { SlotSection } from "./slot-section"
 import { useScrollFixRef } from "@/hooks/use-scroll-fix-ref"
@@ -34,8 +39,12 @@ import {
 const API_URL = "https://api.luzmo.com"
 
 export function GuidedWizard() {
-  const { state, dispatch, datasetIds } = useApp()
+  const { state, dispatch, allowedDatasetIds } = useApp()
   const draft = state.modal.draft
+  const filterDatasetIds = useMemo(
+    () => getDatasetIdsFromSlots(draft.slotsContents),
+    [draft.slotsContents],
+  )
 
   const isEditMode = state.modal.editingItemId !== null
   const [step, setStep] = useState(() => {
@@ -380,7 +389,7 @@ export function GuidedWizard() {
     // @ts-expect-error -- ACK web component
     <luzmo-data-field-panel
       ref={dataFieldsPanelRef}
-      dataset-ids={JSON.stringify(datasetIds)}
+      dataset-ids={JSON.stringify(allowedDatasetIds)}
       api-url={API_URL}
       dataset-picker
       search="auto"
@@ -461,6 +470,18 @@ export function GuidedWizard() {
             <div>itemType: <span className="text-blue-500">{draft.type}</span></div>
             <div>hasContent: {String(hasContent)}</div>
             <div>isEditing: {String(isEditing)}</div>
+            <div className="mt-1">
+              allowed (env):{" "}
+              {allowedDatasetIds.length > 0
+                ? allowedDatasetIds.join(", ")
+                : "NONE"}
+            </div>
+            <div>
+              chart (slots):{" "}
+              {filterDatasetIds.length > 0
+                ? filterDatasetIds.join(", ")
+                : "NONE"}
+            </div>
           </div>
           <div>
             <div className="font-semibold text-muted-foreground">
@@ -710,7 +731,7 @@ export function GuidedWizard() {
                   className="flex-1 overflow-auto p-2"
                 >
                   <LuzmoFilters
-                    datasetIds={datasetIds}
+                    datasetIds={filterDatasetIds}
                     filters={draft.filters ?? []}
                     apiUrl={API_URL}
                     language="en"

--- a/guided-chart-creator/components/report-builder/table-builder.tsx
+++ b/guided-chart-creator/components/report-builder/table-builder.tsx
@@ -22,6 +22,7 @@ import {
   getNextItemPosition,
   normalizeSlotsContents,
   remapSlotsForTableType,
+  getDatasetIdsFromSlots,
 } from "@/lib/luzmo-types"
 import { tableBuilder as copy } from "@/lib/guidance-copy"
 import { SlotSection } from "./slot-section"
@@ -37,8 +38,12 @@ const SLOT_COLUMN = "column"
 const SLOT_MEASURE = "measure"
 
 export function TableBuilder() {
-  const { state, dispatch, datasetIds } = useApp()
+  const { state, dispatch, allowedDatasetIds } = useApp()
   const draft = state.modal.draft
+  const filterDatasetIds = useMemo(
+    () => getDatasetIdsFromSlots(draft.slotsContents),
+    [draft.slotsContents],
+  )
 
   const columnSlotRef = useRef<HTMLElement>(null)
   const rowSlotRef = useRef<HTMLElement>(null)
@@ -281,7 +286,18 @@ export function TableBuilder() {
           </div>
           <div>
             <div className="font-semibold text-muted-foreground">Datasets</div>
-            <div>datasets: {datasetIds.length > 0 ? datasetIds.join(", ") : "NONE"}</div>
+            <div>
+              allowed (env):{" "}
+              {allowedDatasetIds.length > 0
+                ? allowedDatasetIds.join(", ")
+                : "NONE"}
+            </div>
+            <div>
+              chart (slots):{" "}
+              {filterDatasetIds.length > 0
+                ? filterDatasetIds.join(", ")
+                : "NONE"}
+            </div>
           </div>
         </div>
         <details className="mt-1">
@@ -335,7 +351,7 @@ export function TableBuilder() {
           {/* @ts-expect-error -- ACK web component */}
           <luzmo-data-field-panel
             ref={dataFieldsPanelRef}
-            dataset-ids={JSON.stringify(datasetIds)}
+            dataset-ids={JSON.stringify(allowedDatasetIds)}
             api-url={API_URL}
             dataset-picker
             search="auto"
@@ -468,7 +484,7 @@ export function TableBuilder() {
 
             <TabsContent value="filters" className="flex-1 overflow-auto p-2">
               <LuzmoFilters
-                datasetIds={datasetIds}
+                datasetIds={filterDatasetIds}
                 filters={draft.filters ?? []}
                 apiUrl={API_URL}
                 language="en"

--- a/guided-chart-creator/hooks/use-luzmo-datasets.ts
+++ b/guided-chart-creator/hooks/use-luzmo-datasets.ts
@@ -3,21 +3,22 @@
 import { useMemo } from "react"
 
 /**
- * Reads Luzmo dataset IDs from the NEXT_PUBLIC_LUZMO_DATASET_IDS env var.
+ * Optional picker allow-list from NEXT_PUBLIC_LUZMO_DATASET_IDS.
+ * Does not drive luzmo-filters — filters use datasets from chart slots.
  */
 export function useLuzmoDatasets() {
   return useMemo(() => {
     const raw = process.env.NEXT_PUBLIC_LUZMO_DATASET_IDS ?? ""
 
-    const datasetIds = raw
+    const allowedDatasetIds = raw
       .split(",")
       .map((id) => id.trim())
       .filter(Boolean)
 
     return {
-      datasetIds,
+      allowedDatasetIds,
       error:
-        datasetIds.length === 0
+        allowedDatasetIds.length === 0
           ? "No NEXT_PUBLIC_LUZMO_DATASET_IDS configured"
           : null,
     }

--- a/guided-chart-creator/lib/luzmo-types.ts
+++ b/guided-chart-creator/lib/luzmo-types.ts
@@ -40,6 +40,23 @@ export function normalizeSlotsContents(
 }
 
 /**
+ * Unique dataset IDs linked by fields in chart/table slots.
+ * Used by luzmo-filters (not the env picker allow-list).
+ */
+export function getDatasetIdsFromSlots(
+  slots: VizItemSlots | undefined | null,
+): string[] {
+  const ids = new Set<string>()
+  for (const slot of normalizeSlotsContents(slots)) {
+    for (const content of slot.content) {
+      const id = content.datasetId ?? content.set
+      if (id) ids.add(id)
+    }
+  }
+  return [...ids]
+}
+
+/**
  * Remap internal singular slot names to the names the Flex embed expects
  * for a given table type.
  *

--- a/guided-chart-creator/package-lock.json
+++ b/guided-chart-creator/package-lock.json
@@ -88,7 +88,6 @@
       "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
@@ -110,7 +109,6 @@
       "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -129,6 +127,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -752,6 +751,7 @@
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
       "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
       }
@@ -836,6 +836,7 @@
       "version": "1.0.1-alpha.33",
       "resolved": "https://registry.npmjs.org/@luzmo/icons/-/icons-1.0.1-alpha.33.tgz",
       "integrity": "sha512-nUchks6BQSJq+EhV+t1lLobePqbQR9Wd/W9XPRZmSGDsVsOhwDNLFI90MEde5R9ZuDJh7WJC4Qo193ZErGU93Q==",
+      "peer": true,
       "peerDependencies": {
         "lit-html": "^3.2.1"
       }
@@ -1179,6 +1180,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.21.6.tgz",
       "integrity": "sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.21.6",
         "@module-federation/webpack-bundler-runtime": "0.21.6"
@@ -1217,7 +1219,6 @@
       "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.5.0",
         "@emnapi/runtime": "^1.5.0",
@@ -3006,7 +3007,6 @@
       "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.9.tgz",
       "integrity": "sha512-A56e0NdfNwbOSJoilMkxzaPuVYaKCNn1shuiwWnCIBmhV9ix1n9S1XvquDjkGyv+gCdR1+zfJBOa5DMB7htLHw==",
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "@rspack/binding-darwin-arm64": "1.7.9",
         "@rspack/binding-darwin-x64": "1.7.9",
@@ -3031,8 +3031,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
       "version": "1.7.9",
@@ -3045,8 +3044,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
       "version": "1.7.9",
@@ -3059,8 +3057,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
       "version": "1.7.9",
@@ -3073,8 +3070,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
       "version": "1.7.9",
@@ -3087,8 +3083,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
       "version": "1.7.9",
@@ -3101,8 +3096,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
       "version": "1.7.9",
@@ -3113,7 +3107,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "1.0.7"
       }
@@ -3129,8 +3122,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
       "version": "1.7.9",
@@ -3143,8 +3135,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
       "version": "1.7.9",
@@ -3157,15 +3148,13 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/core": {
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.9.tgz",
       "integrity": "sha512-VHuSKvRkuv42Ya+TxEGO0LE0r9+8P4tKGokmomj4R1f/Nu2vtS3yoaIMfC4fR6VuHGd3MZ+KTI0cNNwHfFcskw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.22.0",
         "@rspack/binding": "1.7.9",
@@ -3187,15 +3176,13 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
       "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rspack/core/node_modules/@module-federation/runtime": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
       "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.22.0",
         "@module-federation/runtime-core": "0.22.0",
@@ -3207,7 +3194,6 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
       "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.22.0",
         "@module-federation/sdk": "0.22.0"
@@ -3218,7 +3204,6 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
       "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.22.0",
         "@module-federation/webpack-bundler-runtime": "0.22.0"
@@ -3228,15 +3213,13 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
       "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rspack/core/node_modules/@module-federation/webpack-bundler-runtime": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
       "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.22.0",
         "@module-federation/sdk": "0.22.0"
@@ -3246,15 +3229,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
       "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3620,7 +3601,6 @@
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3646,6 +3626,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3656,6 +3637,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3737,6 +3719,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3958,7 +3941,8 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5004,6 +4988,7 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -5026,6 +5011,7 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -5163,6 +5149,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -5370,6 +5357,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5379,6 +5367,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5625,8 +5614,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/signal-polyfill/-/signal-polyfill-0.2.2.tgz",
       "integrity": "sha512-p63Y4Er5/eMQ9RHg0M0Y64NlsQKpiu6MDdhBXpyywRuWiPywhJTpKJ1iB5K2hJEbFZ0BnDS7ZkJ+0AfTuL37Rg==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/sorted-array-functions": {
       "version": "1.3.0",
@@ -5854,6 +5842,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5979,6 +5968,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
## Summary

Fixes the `<luzmo-filters>` wiring in the guided chart creator so it uses the dataset associated with the active chart/slot instead of falling back to the dataset ID from the environment config.

## Testing

- Ran the app locally
- Confirmed filters now follow the displayed chart/slot dataset
- Ran `npm run build`