### PR TITLE
Add Dependabot configuration for monorepo dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,121 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/ack-maps-builder"
+      - "/block-type-editor"
+      - "/cfo-cockpit"
+      - "/custom-chart-example/*"
+      - "/dashboard-filter-panel"
+      - "/dashboard-to-flex-grid"
+      - "/devops-command"
+      - "/devops-command/*"
+      - "/euro2024"
+      - "/fifa2026"
+      - "/guided-chart-creator"
+      - "/newspaper"
+      - "/pivot-dataing-app"
+      - "/report-builder"
+      - "/routedata"
+      - "/sales-compass"
+      - "/sales-compass/*"
+      - "/sustain-iq"
+      - "/the-constructor"
+      - "/wearables-dashboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Brussels"
+    target-branch: "main"
+    open-pull-requests-limit: 3
+    cooldown:
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 30
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      angular-patch-minor:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@ngtools/*"
+        update-types:
+          - "patch"
+          - "minor"
+        group-by: "dependency-name"
+      angular-major:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@ngtools/*"
+        update-types:
+          - "major"
+        group-by: "dependency-name"
+      luzmo-patch-minor:
+        patterns:
+          - "@luzmo/*"
+        update-types:
+          - "patch"
+          - "minor"
+        group-by: "dependency-name"
+      luzmo-major:
+        patterns:
+          - "@luzmo/*"
+        update-types:
+          - "major"
+        group-by: "dependency-name"
+      misc-patch-minor:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@ngtools/*"
+          - "@luzmo/*"
+        update-types:
+          - "patch"
+          - "minor"
+        group-by: "dependency-name"
+      misc-major:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@ngtools/*"
+          - "@luzmo/*"
+        update-types:
+          - "major"
+        group-by: "dependency-name"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "Europe/Brussels"
+    target-branch: "main"
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      actions-patch-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## What changed

Adds a repository-level `.github/dependabot.yml` to manage dependency updates across the showcases monorepo and GitHub Actions.

## Why

The repository has accumulated a large Dependabot backlog. This config is meant to make future updates much easier to manage by reducing PR volume and grouping related changes more predictably.

## What the config does

- Enables scheduled Dependabot updates for npm projects in the repo
- Adds a separate update rule for GitHub Actions
- Limits the number of open Dependabot PRs at a time
- Adds cooldown periods so patch, minor, and major updates do not all arrive at once
- Groups Angular, Luzmo, and other dependencies into more reviewable PRs
- Uses safe glob patterns for nested package folders where appropriate

## Notes

- This only affects future Dependabot runs
- It does not automatically clean up or modify the existing open Dependabot PR backlog
- Top-level package directories are kept explicit to avoid matching non-package folders too broadly

## Expected impact

After this is merged, new Dependabot PRs should arrive in smaller waves and be easier to review and merge consistently.